### PR TITLE
Fix `key` command for shortcuts that contain letters

### DIFF
--- a/Commands/Key.cpp
+++ b/Commands/Key.cpp
@@ -66,7 +66,7 @@ static std::vector<int> KeyStroke2Code(const std::string &ks) {
 		if (t_ks != KeyStringTable.end()) {
 			list_keycodes.push_back(t_ks->second);
 		} else {
-			auto t_kts = KeyTextStringTable.find(it[0]);
+			auto t_kts = KeyTextStringTable.find(tolower(it[0]));
 
 			if (t_kts != KeyTextStringTable.end()) {
 				list_keycodes.push_back(t_kts->second);


### PR DESCRIPTION
Thank you for your project! It seems like this is the only way to simulate input on wayland right now.

KeyTextStringTable contains only lowercase keys. So, map lookup at line 69 always fails, since everything is converted to upper case at line 61.

After lowering the key back, shortcuts like 'ctrl-t' work fine.