### PR TITLE
Fix the systemd service

### DIFF
--- a/Daemon/ydotool.service
+++ b/Daemon/ydotool.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Starts ydotoold service
-After=network.target
 
 [Service]
 Type=simple
@@ -11,4 +10,4 @@ KillMode=process
 TimeoutSec=180
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
- `multi-user.target` does not exist for user instances of systemd, so enabling the service is a no-op; use the correct `default.target`
- ydotool does not require the network to be up, so `After=network.target` is superfluous