### PR TITLE
Key command: Support sending extra keyboard keys

### DIFF
--- a/Tools/Key/Key.cpp
+++ b/Tools/Key/Key.cpp
@@ -75,6 +75,12 @@ static std::vector<int> KeyStroke2Code(const std::string &ks) {
 			continue;
 		}
 
+		auto t_kcs = Table_KeyCodes.find(it);
+		if (t_kcs != Table_KeyCodes.end()) {
+			list_keycodes.push_back(t_kcs->second);
+			continue;
+		}
+
 		auto t_ks = Table_FunctionKeys.find(it);
 		if (t_ks != Table_FunctionKeys.end()) {
 			list_keycodes.push_back(t_ks->second);


### PR DESCRIPTION
At the moment, extra keys such as KEY_BACK and KEY_FORWARD are misinterpreted as the "K" key.

ydotool can be very useful for testing keybindings in applications, particularly if the keys to be tested 
are not available in the tester's keyboard. That's often the case for most keys in the evdevPlus::Table_KeyCodes