### PR TITLE
Fix: Recorder: Populate input device list when no devices are specified

### DIFF
--- a/Tools/Recorder/Recorder.cpp
+++ b/Tools/Recorder/Recorder.cpp
@@ -137,7 +137,7 @@ int Recorder::run(int argc, char **argv) {
 	}
 
 	if (mode == 1) {
-		if (device_list.empty()) {
+		if (device_list.empty() || (device_list.size() == 1 && device_list[0] == "")) {
 			device_list = find_all_devices();
 
 			if (device_list.empty()) {


### PR DESCRIPTION
ydotool has automatically provided a default device list when the user
did not specify one for a while. However, when the cxxopts library was
updated in
https://github.com/ReimuNotMoe/ydotool/commit/f4e91671187feb32c0564010f75a79e52539b0bd
the behavior of the default flag value function changed; now because the
lambda for the devices flag emits an empty string (""), the device list
is no longer empty. So this change adds an additional check to check if
the only value in the device list returned by cxxopts is just a single
empty string; in this case go ahead and populate a default device list
using the old method.

NOTE: It is possible that the user may now specify --devices "", and
this change will cause the defaults to be used anyway.

Signed-off-by: Brendan Higgins <bhig93@gmail.com>