### PR TITLE
Re-introduce stdin option for --file

### DIFF
--- a/Client/tool_type.c
+++ b/Client/tool_type.c
@@ -179,7 +179,9 @@ int tool_type(int argc, char **argv) {
 	}
 
 	if (file_path) {
-		int fd = open(file_path, O_RDONLY);
+		int fd = (strcmp(file_path, "-") == 0)
+				? STDIN_FILENO
+				: open(file_path, O_RDONLY);
 
 		if (fd == -1) {
 			fprintf(stderr, "ydotool: type: error: failed to open %s: %s\n", file_path,


### PR DESCRIPTION
Docs specify it should do this, but it seems to have gotten dropped in the rewrite. Now it does again!

A bunch of style options here, if ternaries are :-1: or we want to preserve the pre-rewrite behavior of logging that we're reading form stdin, then I'm happy to change to a plain if.