### PR TITLE
Add string.h include

### DIFF
--- a/Client/tool_key.c
+++ b/Client/tool_key.c
@@ -35,6 +35,7 @@
 */
 
 #include "ydotool.h"
+#include <string.h>
 
 static void show_help() {
 	puts(

--- a/Client/tool_type.c
+++ b/Client/tool_type.c
@@ -35,6 +35,7 @@
 */
 
 #include "ydotool.h"
+#include <string.h>
 
 #define FLAG_UPPERCASE		0x80000000
 

--- a/Client/ydotool.c
+++ b/Client/ydotool.c
@@ -35,6 +35,7 @@
 */
 
 #include "ydotool.h"
+#include <string.h>
 
 struct tool_def {
 	char name[16];

--- a/Daemon/ydotoold.c
+++ b/Daemon/ydotoold.c
@@ -40,6 +40,7 @@
 #include <assert.h>
 #include <time.h>
 #include <signal.h>
+#include <string.h>
 
 #include <getopt.h>
 


### PR DESCRIPTION
This should silence strncpy, strncmp, strchr and strerror warnings w/ -Wbuiltin-declaration-mismatch and -Wformat.