### PR TITLE
Use XDG_RUNTIME_DIR var if set

### DIFF
--- a/Client/ydotool.c
+++ b/Client/ydotool.c
@@ -129,10 +129,10 @@ int main(int argc, char **argv) {
 
 	const char *daemon_socket_path;
 
-	char *env_sp = getenv("YDOTOOL_SOCKET");
-
-	if (env_sp) {
-		daemon_socket_path = env_sp;
+	if (getenv("YDOTOOL_SOCKET")) {
+		daemon_socket_path = strcat(getenv("XDG_RUNTIME_DIR"), "/.ydotool_socket");
+	} else if (getenv("XDG_RUNTIME_DIR")){
+		daemon_socket_path = getenv("YDOTOOL_SOCKET");
 	} else {
 		daemon_socket_path = "/tmp/.ydotool_socket";
 	}

--- a/Daemon/ydotoold.c
+++ b/Daemon/ydotoold.c
@@ -134,6 +134,11 @@ static void uinput_setup(int fd) {
 }
 
 int main(int argc, char **argv) {
+
+	if (getenv("XDG_RUNTIME_DIR")) {
+		opt_socket_path = strcat(getenv("XDG_RUNTIME_DIR"), "/.ydotool_socket");
+	}
+
 	while (1) {
 		int c;
 


### PR DESCRIPTION
As ydotool can be used w/o a graphical environment and the recommended systemd service is a user one, let's use `XDG_RUNTIME_DIR` as a default if no `--socket-path` is set for the daemon. If none of them aren't set -> fallback to `/tmp`

For the client use `XDG_VAR_RUNTIME_DIR` if set, otherwise fallback to `/tmp`.

Excuse me if I've misunderstood how the tool can be used (and for the non-idiomatic C-code).