### PR TITLE
Fail gracefully during configuration if 'scdoc' is missing

### DIFF
--- a/manpage/CMakeLists.txt
+++ b/manpage/CMakeLists.txt
@@ -1,7 +1,12 @@
+find_program(SCDOC scdoc)
+if(NOT SCDOC)
+  message(FATAL_ERROR "scdoc not found")
+endif()
+
 function(man_page section page)
   set(src "${CMAKE_CURRENT_SOURCE_DIR}/${page}.${section}.scd")
   set(bin "${CMAKE_CURRENT_BINARY_DIR}/${page}.${section}")
-  add_custom_target(${page}.${section} ALL COMMAND scdoc < ${src} > ${bin})
+  add_custom_target(${page}.${section} ALL COMMAND ${SCDOC} < ${src} > ${bin})
   install(FILES ${bin} DESTINATION ${CMAKE_INSTALL_MANDIR}/man${section}/)
 endfunction(man_page)
 


### PR DESCRIPTION
Prior to this change, compilation would fail midway through when trying to run `scdoc`. This change uses a follow up check and `FATAL_ERROR` instead of `REQUIRED` to `find_program` because `REQUIRED` was only added in CMake 3.18.