### PR TITLE
Update ydotoold.c

### DIFF
--- a/Daemon/ydotoold.c
+++ b/Daemon/ydotoold.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv) {
 				opt_ui_setup &= ~ENABLE_KEY;
 				break;
 
-			case 'A':
+			case 'T':
 				opt_ui_setup |= ENABLE_ABS;
 				break;
 


### PR DESCRIPTION
The argument list and argument parsing switch statement disagree, the argument list uses "--touch-on"/"-T" to set ENABLE_ABS, while the switch statement was expecting "-A" (likely for "--absolute-on", or "--absolute-enable", or similar).