### PR TITLE
Build documentation is opt-out on CMake

### DIFF
--- a/manpage/CMakeLists.txt
+++ b/manpage/CMakeLists.txt
@@ -1,8 +1,3 @@
-find_program(SCDOC scdoc)
-if(NOT SCDOC)
-  message(FATAL_ERROR "scdoc not found")
-endif()
-
 function(man_page section page)
   set(src "${CMAKE_CURRENT_SOURCE_DIR}/${page}.${section}.scd")
   set(bin "${CMAKE_CURRENT_BINARY_DIR}/${page}.${section}")
@@ -10,5 +5,15 @@ function(man_page section page)
   install(FILES ${bin} DESTINATION ${CMAKE_INSTALL_MANDIR}/man${section}/)
 endfunction(man_page)
 
-man_page(1 ydotool)
-man_page(8 ydotoold)
+option(BUILD_DOCS "build documentation (requires scdoc)" ON)
+
+find_program(SCDOC scdoc)
+
+if(BUILD_DOCS AND NOT SCDOC)
+    message(FATAL_ERROR "build documentation selected, but scdoc could not be found")
+endif()
+
+if(BUILD_DOCS)
+  man_page(1 ydotool)
+  man_page(8 ydotoold)
+endif()


### PR DESCRIPTION
Due to some distros relying on building its own packages, enable the possibility to build and use ydotool without the need to have `scdoc` as dependency.