### PR TITLE
Upgrade CMake to 3.22 and C to 2011

### DIFF
--- a/.github/workflows/push_pr_build_cmake.yml
+++ b/.github/workflows/push_pr_build_cmake.yml
@@ -18,22 +18,23 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: cmake -E make_directory ${{github.workspace}}/build
 
+      - name: Install scdoc needed for manpage
+        run: |
+          sudo apt-get update && sudo apt-get install scdoc
+
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
         working-directory: ${{github.workspace}}/build
-        # Note the current convention is to use the -S and -B options here to specify source
-        # and build directories, but this is only available with CMake 3.13 and higher.
-        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        run: cmake -S .. -B . -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         working-directory: ${{github.workspace}}/build
@@ -49,7 +50,7 @@ jobs:
           mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-${{matrix.os}}
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}} build artifact
           path: |

--- a/.github/workflows/release_cmake.yml
+++ b/.github/workflows/release_cmake.yml
@@ -21,22 +21,23 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: cmake -E make_directory ${{github.workspace}}/build
+          
+      - name: Install scdoc needed for manpage
+        run: |
+          sudo apt-get update && sudo apt-get install scdoc
 
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
         working-directory: ${{github.workspace}}/build
-        # Note the current convention is to use the -S and -B options here to specify source
-        # and build directories, but this is only available with CMake 3.13 and higher.
-        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        run: cmake -S .. -B . -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         working-directory: ${{github.workspace}}/build
@@ -52,7 +53,7 @@ jobs:
           mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-release-${{matrix.os}}
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}} build artifact
           path: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.22)
 project(ydotool C)
 
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 11)
 
 # Include GNU install directory module to detect where to install
 # files on Linux/Unix systems (e.g., lib vs lib64)
@@ -24,8 +24,6 @@ if (${RC_GIT_VER} EQUAL 0)
     message("-- Version: " ${GIT_VERSION})
     add_definitions(-DVERSION=\"${GIT_VERSION}\")
 endif()
-
-
 
 set(SOURCE_FILES_DAEMON Daemon/ydotoold.c)
 set(SOURCE_FILES_CLIENT Client/ydotool.c Client/tool_click.c Client/tool_mousemove.c Client/tool_type.c Client/tool_key.c)


### PR DESCRIPTION
Upgrade CMake to the latest on Ubuntu 22.04 (LTS) and C Standard to 2011. We still can improve the code adding more warnings on gcc

Closes #225 

Updates CI to always install `scdoc` before running CMake