### PR TITLE
Silently run xinput due to warnings for (X)Wayland users

### DIFF
--- a/Daemon/ydotoold.c
+++ b/Daemon/ydotoold.c
@@ -361,14 +361,17 @@ int main(int argc, char **argv) {
 			pid_t npid = vfork();
 
 			if (npid == 0) {
+				// Make sure we don't warning unnecessarily if user is on XWayland session
+				freopen("/dev/null", "w", stderr);
+
 				execl(xinput_path, "xinput", "--set-prop", "pointer:ydotoold virtual device", "libinput Accel Profile Enabled", "0,", "1", NULL);
-				perror("failed to run xinput command");
+				printf("failed to run xinput command\n");
 				_exit(2);
 			} else if (npid == -1) {
 				perror("failed to fork");
 			}
 		} else {
-			printf("xinput command not found in `%s', not disabling mouser pointer acceleration", xinput_path);
+			printf("xinput command not found in `%s', not disabling mouser pointer acceleration\n", xinput_path);
 		}
 	}
 


### PR DESCRIPTION
I considered to go for WAYLAND_DIPSLAY envvar, but that's not exactly there if we're running as root, which is mostly needed for the daemon.
Also considered another ways which would not be reliable... At least not as much as xinput itself does, using Xlibs, which seemed overkill for this situation.

So I went with running it silently, so we know that won't hurt the functionality, it'd just not work. 
I could also use xinput to first check if we were into a (x)wayland session, but that would only make twice the call which is not really needed.

Currently there's no standard way among the compositors to check if we're in a session (AFAIK). 
Feel free to let me know if there's a better way.

Closes #205 