### PR TITLE
Add arm64 build support

### DIFF
--- a/.github/workflows/push_pr_build_cmake.yml
+++ b/.github/workflows/push_pr_build_cmake.yml
@@ -12,10 +12,14 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-latest-arm64
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -45,16 +49,16 @@ jobs:
 
       - name: Rename build files
         run: |
-          mv ${{github.workspace}}/build/ydotool ${{github.workspace}}/build/ydotool-${{matrix.os}}
-          mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-${{matrix.os}}
-          mv ${{github.workspace}}/build/ydotoold.service ${{github.workspace}}/build/ydotoold-${{matrix.os}}.service
+          mv ${{github.workspace}}/build/ydotool ${{github.workspace}}/build/ydotool-${{matrix.arch}}
+          mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-${{matrix.arch}}
+          mv ${{github.workspace}}/build/ydotoold.service ${{github.workspace}}/build/ydotoold-${{matrix.arch}}.service
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.os}} build artifact
+          name: ${{matrix.arch}} build artifact
           path: |
-            ${{github.workspace}}/build/ydotool-${{matrix.os}}
-            ${{github.workspace}}/build/ydotoold-${{matrix.os}}
-            ${{github.workspace}}/build/ydotoold-${{matrix.os}}.service
+            ${{github.workspace}}/build/ydotool-${{matrix.arch}}
+            ${{github.workspace}}/build/ydotoold-${{matrix.arch}}
+            ${{github.workspace}}/build/ydotoold-${{matrix.arch}}.service
 

--- a/.github/workflows/push_pr_build_cmake.yml
+++ b/.github/workflows/push_pr_build_cmake.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - runner: ubuntu-latest
             arch: x86_64
-          - runner: ubuntu-latest-arm64
+          - runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:

--- a/.github/workflows/release_cmake.yml
+++ b/.github/workflows/release_cmake.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - runner: ubuntu-latest
             arch: x86_64
-          - runner: ubuntu-latest-arm64
+          - runner: ubuntu-24.04-arm
             arch: arm64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release_cmake.yml
+++ b/.github/workflows/release_cmake.yml
@@ -15,11 +15,14 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-latest-arm64
+            arch: arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -49,24 +52,24 @@ jobs:
 
       - name: Rename build files
         run: |
-          mv ${{github.workspace}}/build/ydotool ${{github.workspace}}/build/ydotool-release-${{matrix.os}}
-          mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-release-${{matrix.os}}
+          mv ${{github.workspace}}/build/ydotool ${{github.workspace}}/build/ydotool-release-${{matrix.arch}}
+          mv ${{github.workspace}}/build/ydotoold ${{github.workspace}}/build/ydotoold-release-${{matrix.arch}}
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.os}} build artifact
+          name: ${{matrix.arch}} build artifact
           path: |
-            ${{github.workspace}}/build/ydotool-release-${{matrix.os}}
-            ${{github.workspace}}/build/ydotoold-release-${{matrix.os}}
+            ${{github.workspace}}/build/ydotool-release-${{matrix.arch}}
+            ${{github.workspace}}/build/ydotoold-release-${{matrix.arch}}
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ${{github.workspace}}/build/ydotool-release-${{matrix.os}}
-            ${{github.workspace}}/build/ydotoold-release-${{matrix.os}}
+            ${{github.workspace}}/build/ydotool-release-${{matrix.arch}}
+            ${{github.workspace}}/build/ydotoold-release-${{matrix.arch}}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
This PR adds build and release support for the `arm64` architecture.

The motivation for this change is to simplify the use of `ydotool` in a project I am currently working on - [PiOSK](https://github.com/debloper/piosk), a tool that sets up Raspberry Pi devices in kiosk mode. 
Adding pre-built `arm64` binaries to each release removes the need for users to compile from source on ARM-based systems.

This benefits anyone using `ydotool` on a Raspberry Pi or other ARM64 devices.

