### PR TITLE
Use opt_key_hold_ms for shift keypress when typing upper case

### DIFF
--- a/Client/tool_type.c
+++ b/Client/tool_type.c
@@ -118,6 +118,7 @@ static void type_char(char c, bool delay) {
 
 	if (kdef & FLAG_UPPERCASE) {
 		uinput_emit(EV_KEY, KEY_LEFTSHIFT, 1, 1);
+		usleep(opt_key_hold_ms * 1000);
 	}
 	uinput_emit(EV_KEY, kc, 1, 1);
 


### PR DESCRIPTION
Capitisation of output was incorrect in some programs because there was no delay between the shift keypress and the letter being typed. Hold time between shift and letter seems like the natural emulation of real typing action, and solves the problem.